### PR TITLE
Increased delay to 700ms

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var exec = require("child_process").exec,
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
-    limiter = new RateLimiter(1, 200); //limit requests to one per 200ms
+    limiter = new RateLimiter(1, 700); //limit requests to one per 200ms
     homebridge.registerAccessory("homebridge-rfoutlets",
         "RFOutlet",
         RFOutletAccessory);


### PR DESCRIPTION
When issuing commands in rapid succession i.e. with a scene or automation the lowest acceptable delay seems to be 700ms. Based on a lot of trial and error with etekcity outlets.